### PR TITLE
Reset files attributes after render

### DIFF
--- a/src/Eusonlito/LaravelPacker/Packer.php
+++ b/src/Eusonlito/LaravelPacker/Packer.php
@@ -426,6 +426,10 @@ class Packer
         } else {
             $list = $this->storage.$this->name;
         }
+        
+        $this->files = [];
+        $this->storage = '';
+        $this->name = '';
 
         $this->force['current'] = $this->force['previous'];
 


### PR DESCRIPTION
Reset files attributes to avoid image duplication when missing. After setting images_fake to false and using cache, when looping a collection of images with some of them missing Packer returns the previous one. This patch resets some properties to avoid it.