### PR TITLE
Add Laravel 5.5 auto discovery feature

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,15 @@
             "src/Eusonlito/LaravelPacker/Exceptions.php"
         ]
     },
-    "minimum-stability": "stable"
+    "minimum-stability": "stable",
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Eusonlito\\LaravelPacker\\PackerServiceProvider"
+            ],
+            "aliases": {
+                "Packer": "Eusonlito\\LaravelPacker\\Facade"
+            }      
+        }
+    }  
 }


### PR DESCRIPTION
With this, on LV5.5, we won't need to add provider and alias manually in `config/app.php` file.